### PR TITLE
<FIX>: 카카오 로그인 수정

### DIFF
--- a/src/api/user/controller/user.controller.ts
+++ b/src/api/user/controller/user.controller.ts
@@ -61,7 +61,7 @@ export class UserController {
 
   @UseGuards(KakaoAuthGuard)
   @Get('/auth/kakao')
-  async kakaoLoginCallBack(@Req() req, @Query('code') code: string) {
+  async kakaoLogin(@Req() req, @Query('code') code: string) {
     const { accessToken, refreshToken } = req.user;
 
     return {

--- a/src/auth/kakao/kakao.strategy.ts
+++ b/src/auth/kakao/kakao.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-kakao';
 import { UserService } from 'src/api/user/service/user.service';
@@ -17,18 +17,24 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
   }
 
   async validate(
-    access_token: string,
-    refresh_token: string,
+    _: string,
+    __: string,
     profile: any,
   ): Promise<{ accessToken: string; refreshToken: string }> {
+    if (!profile._json) {
+      throw new UnauthorizedException('카카오 인증에 실패하였습니다.');
+    }
+
     let user = await this.userService.findUserByLoginId(profile.id);
+
+    const userNickname = profile.username + Math.floor(Math.random() * 10000);
 
     if (!user) {
       const newUser = await this.userService.signUp({
         login_id: profile.id,
         password: '',
         confirm_password: '',
-        nickname: profile._json.kakao_account.email,
+        nickname: userNickname,
         mbti: '',
         provider: 'kakao',
       });


### PR DESCRIPTION
이메일 동의를 안할경우 500에러 발생
nickname을 username으로 사용
modified:   src/api/user/controller/user.controller.ts
modified:   src/auth/kakao/kakao.strategy.ts