### PR TITLE
<FIX>: feed 조회 쿼리 수정

### DIFF
--- a/src/api/feed/feed.repository.ts
+++ b/src/api/feed/feed.repository.ts
@@ -64,12 +64,6 @@ export class FeedRepository {
           as: 'like',
           attributes: [],
         },
-        {
-          required: false,
-          model: Pick,
-          as: 'pick',
-          attributes: [],
-        },
       ],
       where: { group_user_id: { [Op.eq]: null } },
       group: ['feed_id'],
@@ -88,7 +82,6 @@ export class FeedRepository {
           attributes: [],
         },
         { model: Like, as: 'like', attributes: [] },
-        { model: Pick, as: 'pick', attributes: [], required: false },
       ],
       where: {
         feed_id,
@@ -262,12 +255,6 @@ export class FeedRepository {
           model: Like,
           as: 'like',
           attributes: [],
-        },
-        {
-          model: Pick,
-          as: 'pick',
-          attributes: [],
-          required: false,
         },
       ],
 

--- a/src/api/user/user.repository.ts
+++ b/src/api/user/user.repository.ts
@@ -71,6 +71,7 @@ export class UserRepository {
         'location',
         [Sequelize.col('user.user_id'), 'user_id'],
         [Sequelize.col('user.mbti'), 'mbti'],
+        [Sequelize.fn('COUNT', Sequelize.col('like.like_id')), 'like_count'],
         'created_at',
         'updated_at',
       ],
@@ -83,12 +84,7 @@ export class UserRepository {
         {
           model: Like,
           as: 'like',
-          attributes: [
-            [
-              Sequelize.fn('COUNT', Sequelize.col('like.like_id')),
-              'like_count',
-            ],
-          ],
+          attributes: [],
         },
       ],
       group: ['feed_id'],


### PR DESCRIPTION
마이피드 조회시 like.like_count -> like_count로 통일
찜목록 추가시 좋아요 개수가 2배로 카운트 되는 문제 해결
modified:   src/api/feed/feed.repository.ts
modified:   src/api/user/user.repository.ts